### PR TITLE
Property name 'body' -> 'app' in App.swift

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -9,7 +9,7 @@ public class App: WebApp {
     
     @State var theme: Theme = .happy
     
-    @AppBuilder public override var body: AppBuilder.Content {
+    @AppBuilder public override var app: AppBuilder.Content {
         Lifecycle.didFinishLaunching {
             Navigator.shared.serviceWorker?.register("./service.js")
             print("Lifecycle.didFinishLaunching")


### PR DESCRIPTION
```swift
@AppBuilder public override var body: AppBuilder.Content {
```

This code causes the error 'Property does not override any property from its superclass'.
I think this is because 'body' was renamed 'app'.

```
// Webapp.swift
...
@AppBuilder open var app: AppBuilder.Content { _AppContent(appBuilderContent: .none) }
...
```

So I changed the name of "body" in the "App.swift" code to "app".